### PR TITLE
(SIMP-914) Fix malformed `%changelog` date

### DIFF
--- a/build/pupmod-mcollective.spec
+++ b/build/pupmod-mcollective.spec
@@ -52,7 +52,7 @@ mkdir -p %{buildroot}/%{prefix}/mcollective
 # Post uninstall stuff
 
 %changelog
-* Mon Jan 18 2015 Nick Markowski <nmarkowski@keywcorp.com> - 2.3.1-0
+* Mon Jan 19 2015 Nick Markowski <nmarkowski@keywcorp.com> - 2.3.1-0
 - Module forked from voxpupuli/puppet-mcollective
   (https://github.com/voxpupuli/puppet-mcollective)
 - Added in mco_autokey generation.


### PR DESCRIPTION
SIMP-914 #comment Fixed `%changelog` date in `pupmod-simp-mcollective`
