### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,10 +2,10 @@
 fixtures:
   repositories:
     datacat:
-      repo: 'https://github.com/richardc/puppet-datacat.git'
-      ref: '0.5.0'
+      repo: https://github.com/richardc/puppet-datacat.git
+      ref: 0.5.0
     stdlib:
-      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.2.0'
+      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
+      ref: 4.2.0
   symlinks:
-    mcollective: '#{source_dir}'
+    mcollective: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in mcollective
