### PR TITLE
(SIMP-2670) Update invalid dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-puppetlabs-java_ks < 2.0.0-0
-Requires: pupmod-puppetlabs-java_ks >= 1.4.0-0
+Requires: pupmod-puppetlabs-java_ks >= 1.4.1-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
 Requires: pupmod-richardc-datacat < 1.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "simp-mcollective",
   "version": "3.0.0",
   "author": "SIMP Team",
-  "summary": "Installs, configures, and manages MCollective agents, clients, and middleware of an MCollective cluster. Forked from voxpupuli/puppet-mcollective",
+  "summary": "Manages MCollective agents, clients, and middleware of an MCollective cluster. Forked from voxpupuli/puppet-mcollective",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-mcollective",
   "project_page": "https://github.com/simp/pupmod-simp-mcollective",
@@ -17,12 +17,12 @@
   "description": "SIMP MCollective Puppet Module",
   "dependencies": [
     {
-      "name": "simp/puppet-datacat",
+      "name": "richardc/datacat",
       "version_requirement": ">= 0.6.2 < 1.0.0"
     },
     {
-      "name": "simp/puppetlabs-java_ks",
-      "version_requirement": ">= 1.4.0 < 2.0.0"
+      "name": "puppetlabs/java_ks",
+      "version_requirement": ">= 1.4.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` referred to
non-existent modules that would be invalid on the forge.

This commit resolves the issue by updating the modules for each
dependency in `metadata.json` to reflect the modules found in
SIMP-6.0.0.

SIMP-2670 #comment Fixed `pupmod-simp-mcollective`